### PR TITLE
target addresses of listening ports and add control for troubleshooting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
+inspec.lock
 Berksfile.lock
 .vagrant/

--- a/controls/ssl_test.rb
+++ b/controls/ssl_test.rb
@@ -25,6 +25,9 @@ invalid_targets = %w{
   ::
 }
 
+# Array of TCP ports to exclude from SSL checking. For example: [443, 8443]
+exclude_ports = []
+
 target_hostname = command('hostname').stdout.strip
 
 # Find all TCP ports on the system, IPv4 and IPv6
@@ -49,7 +52,7 @@ end
 
 # Filter out ports that don't respond to any version of SSL
 sslports = tcpports.find_all do |tcpport|
-  ssl(tcpport).enabled?
+  !exclude_ports.include?(tcpport[:port]) && ssl(tcpport).enabled?
 end
 
 # Troubleshooting control to show InSpec version and list

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: Hardening Framework Team, Chef Software Inc.
 copyright_email: hello@dev-sec.io
 license: Apache 2 license
 summary: Demonstrates the use of InSpec's SSL resource
-version: 1.1.1
+version: 1.1.3
 supports:
   - inspec: '>= 0.33.2'


### PR DESCRIPTION
Listening ports can be bound on any interface available on the node. If this is the case, the ssl resource needs to use that IP address and not localhost or target IP.
