### PR TITLE
Added control check for disabled CBC

### DIFF
--- a/controls/ssl_test.rb
+++ b/controls/ssl_test.rb
@@ -143,6 +143,21 @@ control 'tls1.2' do
   end
 end
 
+control 'cbc' do
+  title 'Disable CBC ciphers from all exposed SSL/TLS ports and versions.'
+  impact 0.5
+  only_if { sslports.length > 0 }
+
+  sslports.each do |sslport|
+    # create a description
+    proc_desc = "on node == #{target_hostname} running #{sslport[:socket].process.inspect} (#{sslport[:socket].pid})"
+    describe ssl(sslport).ciphers(/cbc/i) do
+      it(proc_desc) { should_not be_enabled }
+      it { should_not be_enabled }
+    end
+  end
+end
+
 control 'rc4' do
   title 'Disable RC4 ciphers from all exposed SSL/TLS ports and versions.'
   impact 0.5


### PR DESCRIPTION
Hi guys,

since the controls just allow TLS 1.2, I added a control to check for disabled CBC mode.
CBC is not mentioned in the [Modern Configurations by Mozilla](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility) and also has the [Lucky 13 vuln](https://www.imperialviolet.org/2013/02/04/luckythirteen.html).

Open for discussions 💃 

Cheers

Chris

