### PR TITLE
Update minimum inspec version to >=1.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-ssl-benchmark
+ssl-baseline
 ===================
 
-This Compliance Profile demonstrates the use of InSpec's SSL resource
+This Compliance Profile demonstrates the use of InSpec's [SSL resource](https://www.inspec.io/docs/reference/resources/ssl/)
+
+The tests are based on
+- [Mozillas TLS Guidelines](https://wiki.mozilla.org/Security/Server_Side_TLS)
+- [OWASP TLS Cheat Sheet](https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet)
+- [Cipherli.st](https://cipherli.st/)
 
 ## Standalone Usage
 
-Requires [InSpec](https://github.com/chef/inspec) 0.33.2 or newer for execution:
+Requires [InSpec](https://github.com/chef/inspec) 1.21.0 or newer for execution:
 
 ```
 $ git clone https://github.com/dev-sec/ssl-benchmark

--- a/inspec.yml
+++ b/inspec.yml
@@ -7,4 +7,4 @@ copyright_email: hello@dev-sec.io
 license: Apache-2.0
 version: 1.3.0
 supports:
-  - inspec: '>= 0.33.2'
+  - inspec: '>= 1.21.0'


### PR DESCRIPTION
Hi Guys,

from the commit msg - open for discussions:


Update README.md

Because of the changes to sslshake[0][1] and the ssl resource[2],
inspec 1.21.0 [2] is the minimum requirement for running the tests of
the ssl-baseline suite - especially on hosts utilizing SNI and modern ciphers

[0]: https://github.com/arlimus/sslshake/issues/2
[1]: https://github.com/arlimus/sslshake/issues/6
[2]: https://github.com/chef/inspec/commit/e3c695e8e9b59496febe68a3a05d2ce3d7c3e5e5#diff-228320b566c11514045fa3228bcf0d73
[3]: https://github.com/chef/inspec/releases/tag/v1.21.0

Signed-off-by: Christoph Kappel <kappel.christoph@gmail.com>