### PR TITLE
control for robotattack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ssl-baseline
 ===================
 
-This Compliance Profile demonstrates the use of InSpec's [SSL resource](https://www.inspec.io/docs/reference/resources/ssl/)
+This Compliance Profile demonstrates the use of InSpec's [SSL resource](https://www.inspec.io/docs/reference/resources/ssl/) by enforcing strong TLS configuration.
 
 The tests are based on
 - [Mozillas TLS Guidelines](https://wiki.mozilla.org/Security/Server_Side_TLS)
@@ -13,15 +13,19 @@ The tests are based on
 Requires [InSpec](https://github.com/chef/inspec) 1.21.0 or newer for execution:
 
 ```
-$ git clone https://github.com/dev-sec/ssl-benchmark
-$ inspec exec ssl-benchmark
+$ git clone https://github.com/dev-sec/ssl-baseline
+$ inspec exec ssl-baseline
 ```
 
 You can also execute the profile directly from Github:
 
 ```
-$ inspec exec https://github.com/dev-sec/ssl-benchmark
+$ inspec exec https://github.com/dev-sec/ssl-baseline
 ```
+
+## Covered Attacks / Weaknesses
+
+- [Return Of Bleichenbacher's Oracle Threat (ROBOT)](https://robotattack.org/)
 
 ## Contributors + Kudos
 

--- a/controls/ssl_test.rb
+++ b/controls/ssl_test.rb
@@ -563,3 +563,21 @@ control 'mac-null' do
     end
   end
 end
+
+control 'robotattack' do
+  title "Return Of Bleichenbacher's Oracle Threat"
+  desc 'ROBOT is the return of a 19-year-old vulnerability that allows performing RSA decryption and signing operations with the private key of a TLS server.'
+  ref "Paper: Return Of Bleichenbacher's Oracle Threat (ROBOT)", url: 'https://ia.cr/2017/1189'
+  tag 'sslattack', 'tlsattack'
+  impact 0.5
+  only_if { sslports.length > 0 }
+
+  sslports.each do |sslport|
+    # create a description
+    proc_desc = "on node == #{target_hostname} running #{sslport[:socket].process.inspect} (#{sslport[:socket].pid})"
+    describe ssl(sslport).ciphers(/^TLS_RSA/i) do
+      it(proc_desc) { should_not be_enabled }
+      it { should_not be_enabled }
+    end
+  end
+end


### PR DESCRIPTION
Disabling TLS_RSA ciphers based on robotattack.org guide.

Issue #17 