### PR TITLE
Bump version to 1.4.0 and switch to inspec 3 for check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,6 @@
 AllCops:
   Exclude:
   - vendor/**/*
-  - "*/puppet/Puppetfile"
-  - "*/puppet/.tmp/**/*"
-  TargetRubyVersion: 1.9
 Documentation:
   Enabled: false
 AlignParameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [1.4.0](https://github.com/dev-sec/ssl-baseline/tree/1.4.0) (2019-05-14)
+[Full Changelog](https://github.com/dev-sec/ssl-baseline/compare/1.3.0...1.4.0)
+
+**Closed issues:**
+
+- Ubuntu 14.04 unsupported? [\#20](https://github.com/dev-sec/ssl-baseline/issues/20)
+- Control for ROBOT Attack [\#17](https://github.com/dev-sec/ssl-baseline/issues/17)
+
+**Merged pull requests:**
+
+- Update issue templates [\#23](https://github.com/dev-sec/ssl-baseline/pull/23) ([rndmh3ro](https://github.com/rndmh3ro))
+- avoid inspec depricated warning in inspec version 1.51.18 [\#19](https://github.com/dev-sec/ssl-baseline/pull/19) ([Viktor-ret](https://github.com/Viktor-ret))
+- control for robotattack [\#18](https://github.com/dev-sec/ssl-baseline/pull/18) ([supergicko](https://github.com/supergicko))
+- v-update minimum inspec version to \>=1.21.0  [\#16](https://github.com/dev-sec/ssl-baseline/pull/16) ([supergicko](https://github.com/supergicko))
+- use recommended spdx license identifier [\#14](https://github.com/dev-sec/ssl-baseline/pull/14) ([chris-rock](https://github.com/chris-rock))
+- Add configurable attributes. [\#13](https://github.com/dev-sec/ssl-baseline/pull/13) ([rhass](https://github.com/rhass))
+
 ## [1.3.0](https://github.com/dev-sec/ssl-baseline/tree/1.3.0) (2017-05-08)
 [Full Changelog](https://github.com/dev-sec/ssl-baseline/compare/v1.2.0...1.3.0)
 
@@ -7,13 +24,13 @@
 
 - Test for all [\#10](https://github.com/dev-sec/ssl-baseline/pull/10) ([supergicko](https://github.com/supergicko))
 - restrict ruby testing to version 2.3.3 [\#9](https://github.com/dev-sec/ssl-baseline/pull/9) ([atomic111](https://github.com/atomic111))
-- Added control check for disabled CBC [\#8](https://github.com/dev-sec/ssl-baseline/pull/8) ([supergicko](https://github.com/supergicko))
 
 ## [v1.2.0](https://github.com/dev-sec/ssl-baseline/tree/v1.2.0) (2017-03-10)
 [Full Changelog](https://github.com/dev-sec/ssl-baseline/compare/v1.1.3...v1.2.0)
 
 **Merged pull requests:**
 
+- Added control check for disabled CBC [\#8](https://github.com/dev-sec/ssl-baseline/pull/8) ([supergicko](https://github.com/supergicko))
 - Add only\_if to controls [\#7](https://github.com/dev-sec/ssl-baseline/pull/7) ([alexpop](https://github.com/alexpop))
 - Sslports bug [\#6](https://github.com/dev-sec/ssl-baseline/pull/6) ([supergicko](https://github.com/supergicko))
 - add common files [\#5](https://github.com/dev-sec/ssl-baseline/pull/5) ([atomic111](https://github.com/atomic111))

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'highline', '~> 1.6.0'
-gem 'inspec', '~> 1'
-gem 'rack', '1.6.4'
-gem 'rake'
-gem 'rubocop', '~> 0.46.0'
+gem 'highline', '~> 2.0.2'
+gem 'inspec', '~> 3'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 #!/usr/bin/env rake
-# encoding: utf-8
 
 require 'rake/testtask'
 require 'rubocop/rake_task'
@@ -20,23 +19,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'ssl-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/controls/ssl_test.rb
+++ b/controls/ssl_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,7 +5,7 @@ maintainer: DevSec Hardening Framework Team
 copyright: DevSec Hardening Framework Team & Chef Software Inc.
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
-version: 1.3.0
+version: 1.4.0
 supports:
   - inspec_version: '>= 1.21.0'
   - os-family: unix


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:
```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```