### PR TITLE
Fix lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,7 @@ Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
   Max: 30
+# Lint/AmbiguousBlockAssociation is incompatible with RSpec
+# https://github.com/rubocop-hq/rubocop/issues/4222
+Lint/AmbiguousBlockAssociation:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
 
 require 'rake/testtask'
 require 'rubocop/rake_task'

--- a/controls/ssl_test.rb
+++ b/controls/ssl_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,7 +15,7 @@
 # author: Dominik Richter
 # author: Christoph Hartmann
 # author: Alex Pop
-# author: Patrick Münch
+# author: Patrick Muench
 # author: Christoph Kappel
 
 invalid_targets = attribute(
@@ -90,7 +92,7 @@ end
 control 'ssl2' do
   title 'Disable SSL 2 from all exposed SSL ports.'
   impact 1.0
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -105,7 +107,7 @@ end
 control 'ssl3' do
   title 'Disable SSL 3 from all exposed SSL ports.'
   impact 1.0
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -120,7 +122,7 @@ end
 control 'tls1.0' do
   title 'Disable TLS 1.0 on exposed ports.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -135,7 +137,7 @@ end
 control 'tls1.1' do
   title 'Disable TLS 1.1 on exposed ports.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -150,7 +152,7 @@ end
 control 'tls1.2' do
   title 'Enable TLS 1.2 on exposed ports.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -169,7 +171,7 @@ end
 control 'kx-ecdh' do
   title 'Enable ECDH as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -184,7 +186,7 @@ end
 control 'kx-rsa' do
   title 'Disable RSA as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -199,7 +201,7 @@ end
 control 'kx-dh' do
   title 'Disable DH as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -214,7 +216,7 @@ end
 control 'kx-krb5' do
   title 'Disable KRB5 as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -229,7 +231,7 @@ end
 control 'kx-psk' do
   title 'Disable PSK as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -244,7 +246,7 @@ end
 control 'kx-gostr' do
   title 'Disable GOSTR as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -259,7 +261,7 @@ end
 control 'kx-srp' do
   title 'Disable SRP as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -279,7 +281,7 @@ end
 control 'au-ecdsa-rsa' do
   title 'Enable ECDSA or RSA as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -294,7 +296,7 @@ end
 control 'au-anon' do
   title 'Disable ANON as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -309,7 +311,7 @@ end
 control 'au-dss' do
   title 'Disable DSS as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -324,7 +326,7 @@ end
 control 'au-psk' do
   title 'Disable PSK as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -339,7 +341,7 @@ end
 control 'au-export' do
   title 'Disable EXPORT as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -360,7 +362,7 @@ end
 control 'enc-aes-gcm-chacha20' do
   title 'Enable AES256 or AES128 or AES256-GCM or AES128-GCM or CHACHA20 as Enc'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -375,7 +377,7 @@ end
 control 'enc-cbc' do
   title 'Disable CBC as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -390,7 +392,7 @@ end
 control 'enc-rc4' do
   title 'Disable RC4 as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -405,7 +407,7 @@ end
 control 'enc-export' do
   title 'Disable EXPORT as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -420,7 +422,7 @@ end
 control 'enc-des' do
   title 'Disable DES, 3DES as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -435,7 +437,7 @@ end
 control 'enc-enull' do
   title 'Disable eNULL as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -450,7 +452,7 @@ end
 control 'enc-camellia' do
   title 'Disable CAMELLIA as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -465,7 +467,7 @@ end
 control 'enc-seed' do
   title 'Disable SEED as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -480,7 +482,7 @@ end
 control 'enc-idea' do
   title 'Disable IDEA as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -495,7 +497,7 @@ end
 control 'enc-aes-ccm' do
   title 'Disable AES-CCM from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -515,7 +517,7 @@ end
 control 'mac-sha384-sha256-poly1305' do
   title 'Enable SHA384 or SHA256 or POLY1305 as Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -530,7 +532,7 @@ end
 control 'mac-md5' do
   title 'Disable MD5 Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -545,7 +547,7 @@ end
 control 'mac-sha' do
   title 'Disable SHA(1) Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -560,7 +562,7 @@ end
 control 'mac-null' do
   title 'Disable NULL Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description
@@ -578,7 +580,7 @@ control 'robotattack' do
   ref "Paper: Return Of Bleichenbacher's Oracle Threat (ROBOT)", url: 'https://ia.cr/2017/1189'
   tag 'sslattack', 'tlsattack'
   impact 0.5
-  only_if { sslports.length > 0 }
+  only_if { sslports.length.positive? }
 
   sslports.each do |sslport|
     # create a description

--- a/controls/ssl_test.rb
+++ b/controls/ssl_test.rb
@@ -92,7 +92,7 @@ end
 control 'ssl2' do
   title 'Disable SSL 2 from all exposed SSL ports.'
   impact 1.0
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -107,7 +107,7 @@ end
 control 'ssl3' do
   title 'Disable SSL 3 from all exposed SSL ports.'
   impact 1.0
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -122,7 +122,7 @@ end
 control 'tls1.0' do
   title 'Disable TLS 1.0 on exposed ports.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -137,7 +137,7 @@ end
 control 'tls1.1' do
   title 'Disable TLS 1.1 on exposed ports.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -152,7 +152,7 @@ end
 control 'tls1.2' do
   title 'Enable TLS 1.2 on exposed ports.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -171,7 +171,7 @@ end
 control 'kx-ecdh' do
   title 'Enable ECDH as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -186,7 +186,7 @@ end
 control 'kx-rsa' do
   title 'Disable RSA as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -201,7 +201,7 @@ end
 control 'kx-dh' do
   title 'Disable DH as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -216,7 +216,7 @@ end
 control 'kx-krb5' do
   title 'Disable KRB5 as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -231,7 +231,7 @@ end
 control 'kx-psk' do
   title 'Disable PSK as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -246,7 +246,7 @@ end
 control 'kx-gostr' do
   title 'Disable GOSTR as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -261,7 +261,7 @@ end
 control 'kx-srp' do
   title 'Disable SRP as KX from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -281,7 +281,7 @@ end
 control 'au-ecdsa-rsa' do
   title 'Enable ECDSA or RSA as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -296,7 +296,7 @@ end
 control 'au-anon' do
   title 'Disable ANON as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -311,7 +311,7 @@ end
 control 'au-dss' do
   title 'Disable DSS as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -326,7 +326,7 @@ end
 control 'au-psk' do
   title 'Disable PSK as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -341,7 +341,7 @@ end
 control 'au-export' do
   title 'Disable EXPORT as AU from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -362,7 +362,7 @@ end
 control 'enc-aes-gcm-chacha20' do
   title 'Enable AES256 or AES128 or AES256-GCM or AES128-GCM or CHACHA20 as Enc'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -377,7 +377,7 @@ end
 control 'enc-cbc' do
   title 'Disable CBC as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -392,7 +392,7 @@ end
 control 'enc-rc4' do
   title 'Disable RC4 as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -407,7 +407,7 @@ end
 control 'enc-export' do
   title 'Disable EXPORT as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -422,7 +422,7 @@ end
 control 'enc-des' do
   title 'Disable DES, 3DES as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -437,7 +437,7 @@ end
 control 'enc-enull' do
   title 'Disable eNULL as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -452,7 +452,7 @@ end
 control 'enc-camellia' do
   title 'Disable CAMELLIA as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -467,7 +467,7 @@ end
 control 'enc-seed' do
   title 'Disable SEED as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -482,7 +482,7 @@ end
 control 'enc-idea' do
   title 'Disable IDEA as ENC from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -497,7 +497,7 @@ end
 control 'enc-aes-ccm' do
   title 'Disable AES-CCM from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -517,7 +517,7 @@ end
 control 'mac-sha384-sha256-poly1305' do
   title 'Enable SHA384 or SHA256 or POLY1305 as Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -532,7 +532,7 @@ end
 control 'mac-md5' do
   title 'Disable MD5 Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -547,7 +547,7 @@ end
 control 'mac-sha' do
   title 'Disable SHA(1) Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -562,7 +562,7 @@ end
 control 'mac-null' do
   title 'Disable NULL Mac from all exposed SSL/TLS ports and versions.'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description
@@ -580,7 +580,7 @@ control 'robotattack' do
   ref "Paper: Return Of Bleichenbacher's Oracle Threat (ROBOT)", url: 'https://ia.cr/2017/1189'
   tag 'sslattack', 'tlsattack'
   impact 0.5
-  only_if { sslports.length.positive? }
+  only_if { sslports.!empty? }
 
   sslports.each do |sslport|
     # create a description


### PR DESCRIPTION
for all changes rubocop proposes two different options:

```
controls/ssl_test.rb:93:13: C: [Corrected] Style/NumericPredicate: Use sslports.length.positive? instead of sslports.length > 0.
  only_if { sslports.length > 0 }
            ^^^^^^^^^^^^^^^^^^^
controls/ssl_test.rb:93:13: C: [Corrected] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
  only_if { sslports.length > 0 }
            ^^^^^^^^^^^^^^^^^^^
```

the autofix uses the first option, but in this use case the second fix might be better. `sslports.!empty?` seems pretty natural and easy to unserstand, so I changed this.