### PR TITLE
use input instead of attribute

### DIFF
--- a/controls/ssl_test.rb
+++ b/controls/ssl_test.rb
@@ -18,7 +18,7 @@
 # author: Patrick Muench
 # author: Christoph Kappel
 
-invalid_targets = attribute(
+invalid_targets = input(
   'invalid_targets',
   value: [
     '127.0.0.1',
@@ -30,19 +30,19 @@ invalid_targets = attribute(
 )
 
 # Array of TCP ports to exclude from SSL checking. For example: [443, 8443]
-exclude_ports = attribute(
+exclude_ports = input(
   'exclude_ports',
   value: [],
   description: 'Array of TCP ports to exclude from SSL checking'
 )
 
-target_hostname = attribute(
+target_hostname = input(
   'target_hostname',
   value: command('hostname').stdout.strip,
   description: 'Target hostname to check'
 )
 
-force_ssl = attribute(
+force_ssl = input(
   'force_ssl',
   value: false,
   description: 'The profile should not check if SSL is enabled on every port and assume it is'

--- a/inspec.yml
+++ b/inspec.yml
@@ -6,6 +6,7 @@ maintainer: DevSec Hardening Framework Team
 copyright: DevSec Hardening Framework Team & Chef Software Inc.
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
+inspec_version: '>= 4.6.3'
 version: 1.6.4
 supports:
     - inspec_version: '>= 1.21.0'


### PR DESCRIPTION
In the last versions of Inspec and cinc-auditor, attribute is deprecated and input should be used.

https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper/